### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "dotenv": "^8.0.0",
     "http-status": "^1.3.2",
     "i": "^0.3.6",
-    "npm": "^6.9.0",
     "redis": "^2.8.0",
     "reflect-metadata": "0.1.13",
     "request": "^2.88.0",


### PR DESCRIPTION

Hello viniciustodesco!

It seems like you have npm as one of your (dev-) dependency in CNPJValidation.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
